### PR TITLE
Use build/postmate.min.js as main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "postmate",
   "version": "1.0.2",
   "description": "A powerful, simple, promise-based postMessage library",
-  "main": "src/postmate.js",
+  "main": "build/postmate.min.js",
   "devDependencies": {
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-preset-es2015-rollup": "^1.1.1",


### PR DESCRIPTION
This prevents the consumer from having to transpile the code.