### PR TITLE
Add `jsnext:main` to enable easy bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/postmate.min.js",
   "jsnext:main": "src/postmate.js",
   "files": [
+    "src",
     "build"
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.4",
   "description": "A powerful, simple, promise-based postMessage library",
   "main": "build/postmate.min.js",
+  "jsnext:main": "src/postmate.js",
   "files": [
     "build"
   ],


### PR DESCRIPTION
Hello! Hands down, this is exactly what I need. Kudos! But I can't comfortably bundle it because it is already babeled and I am also using babel inside my bundler causing an error.

Therefore, please merge this PR and push a new version to NPM Much gratitude.