### PR TITLE
Add "module" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.0",
   "description": "A powerful, simple, promise-based postMessage library",
   "main": "build/postmate.min.js",
+  "module": "build/postmate.es.js",
   "files": [
     "build",
     "src"


### PR DESCRIPTION
As you build already that file I think you have simply forgotten to add this field into your package.json. Without it bundlers' are not able to resolve that file instead of the one specified in the "main" field when requiring the package.

This change shaved off 27 bytes from my bundle 😉 