### PR TITLE
[Readme] constructor Postmate.Model()

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ new Postmate.Model({
 
 > This is written in the child page. Calling `Postmate.Model` initiates a handshake request listener from the `Child`. Once the handshake is complete, an event listener is bound to receive requests from the `Parent`. The `Child` model is _extended_ from the `model` provided by the `Parent`.
 
-**Returns**: Promise(parent)
+**Returns**: Promise(handshakeMeta)
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ new Postmate.Model({
 });
 ```
 
-> This is written in the child page. Calling `Postmate.Model` initiates a handshake request listener from the `Parent`. Once the handshake is complete, an event listener is bound to receive requests from the `Parent`. The `Child` model is _extended_ from the `model` provided by the `Parent`.
+> This is written in the child page. Calling `Postmate.Model` initiates a handshake request listener from the `Child`. Once the handshake is complete, an event listener is bound to receive requests from the `Parent`. The `Child` model is _extended_ from the `model` provided by the `Parent`.
+
+**Returns**: Promise(parent)
 
 #### Parameters
 


### PR DESCRIPTION
Hi Jacob and Jeff,

I observe some of the Postmate documentation is incorrect/incomplete. Can you confirm both my finds and changes?

<img width="1075" alt="postmate documentation - missing" src="https://user-images.githubusercontent.com/1548933/41513378-b42f45b2-724f-11e8-86d7-e28dfafb7f09.png">
