### PR TITLE
Remove undefined variable

### DIFF
--- a/src/postmate.js
+++ b/src/postmate.js
@@ -281,7 +281,7 @@ class Postmate {
     container = typeof container !== 'undefined' ? container : document.body, // eslint-disable-line no-use-before-define
     model,
     url,
-  } = userOptions) { // eslint-disable-line no-undef
+  }) {
     this.parent = window
     this.frame = document.createElement('iframe')
     container.appendChild(this.frame)


### PR DESCRIPTION
This was wrong as it was using non-existent variable as default in case of the Postmate being called with no arguments