### PR TITLE
Use sanitize when receiving event emits from Child

### DIFF
--- a/src/postmate.js
+++ b/src/postmate.js
@@ -102,7 +102,10 @@ export class ParentAPI {
     }
 
     this.listener = (e) => {
-      const { data, name } = (((e || {}).data || {}).value || {})
+      if (!sanitize(e, this.childOrigin)) return false
+
+      const { data, name } = e.data.value
+
       if (e.data.postmate === 'emit') {
         if (process.env.NODE_ENV !== 'production') {
           log(`Parent: Received event emission: ${name}`)


### PR DESCRIPTION
This unifies how message events are handled across the codebase + actually it's a bug fix as it checks the origin correctly now and guards againt i.e. postMessaged nulls