### PR TITLE
fix(Postmate): added promise rejection on handshake timeout

### DIFF
--- a/src/postmate.js
+++ b/src/postmate.js
@@ -314,7 +314,11 @@ class Postmate {
       this.parent.addEventListener('message', reply, false)
 
       const doSend = () => {
-        attempt++
+        if (++attempt > maxHandshakeRequests) {
+          clearInterval(responseInterval)
+          return reject('Handshake Timeout Reached')
+        }
+
         if (process.env.NODE_ENV !== 'production') {
           log(`Parent: Sending handshake attempt ${attempt}`, { childOrigin })
         }
@@ -323,10 +327,6 @@ class Postmate {
           type: messageType,
           model: this.model,
         }, childOrigin)
-
-        if (attempt === maxHandshakeRequests) {
-          clearInterval(responseInterval)
-        }
       }
 
       const loaded = () => {


### PR DESCRIPTION
## Proposed Changes

- reject initial promise after maximum amount of handshake requests have been sent, without receiving a reply

This is for cases where the target is not available, and `postMessage()` errors like
```
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('<URL>') does not match the recipient window's origin ('null').
```
lead to the initial promise never getting resolved or rejected.